### PR TITLE
Redesign Mahjong GUI layout and assets

### DIFF
--- a/src/mahjong_wrapper.py
+++ b/src/mahjong_wrapper.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional, Tuple
+from pathlib import Path
+from typing import Any, Optional, Tuple
 
 try:
     import pygame
@@ -74,16 +75,32 @@ class MahjongEnv(_BaseMahjongEnv):
         self._fps = max(1, fps)
         self._font_name = font_name
         self._font_size = font_size
-        self._background_color = (20, 25, 35)
-        self._accent_color = (120, 210, 255)
+        self._background_color = (12, 30, 60)
+        self._play_area_color = (24, 60, 90)
+        self._play_area_border = (40, 90, 130)
+        self._panel_color = (5, 5, 5)
+        self._panel_border = (90, 120, 160)
+        self._accent_color = (170, 230, 255)
         self._text_color = (235, 235, 235)
+        self._muted_text_color = (170, 190, 210)
         self._danger_color = (220, 120, 120)
+        self._face_down_color = (18, 18, 22)
+        self._face_down_border = (60, 60, 70)
         self._screen: Optional[pygame.Surface] = None
         self._font: Optional[pygame.font.Font] = None
+        self._small_font: Optional[pygame.font.Font] = None
+        self._header_font: Optional[pygame.font.Font] = None
         self._clock: Optional[pygame.time.Clock] = None
         self._line_height = font_size + 6
         self._quit_requested = False
         self._last_payload = _RenderPayload(action=None, reward=0.0, done=False, info={})
+        self._asset_root = Path(__file__).resolve().parent.parent / "data" / "assets"
+        self._raw_tile_assets: dict[int, pygame.Surface] = {}
+        self._tile_cache: dict[tuple[int, Tuple[int, int]], pygame.Surface] = {}
+        self._tile_orientation_cache: dict[tuple[int, Tuple[int, int], int], pygame.Surface] = {}
+        self._face_down_cache: dict[tuple[Tuple[int, int], int], pygame.Surface] = {}
+        self._placeholder_cache: dict[tuple[int, Tuple[int, int]], pygame.Surface] = {}
+        self._tile_metrics: dict[str, Tuple[int, int]] = {}
         self._ensure_gui()
         super().__init__(*args, **kwargs)
 
@@ -133,8 +150,12 @@ class MahjongEnv(_BaseMahjongEnv):
         self._screen = pygame.display.set_mode(self._window_size, flags)
         pygame.display.set_caption("MahjongEnv GUI")
         self._font = pygame.font.SysFont(self._font_name, self._font_size)
+        small_size = max(12, self._font_size - 4)
+        self._small_font = pygame.font.SysFont(self._font_name, small_size)
+        self._header_font = pygame.font.SysFont(self._font_name, self._font_size + 10)
         self._clock = pygame.time.Clock()
         self._line_height = self._font.get_linesize() + 4
+        self._load_tile_assets()
 
     def _process_events(self) -> None:
         if self._screen is None:
@@ -147,64 +168,556 @@ class MahjongEnv(_BaseMahjongEnv):
                 flags = pygame.RESIZABLE
                 self._screen = pygame.display.set_mode(self._window_size, flags)
 
-    def _hand_to_text(self, tiles: Iterable[int]) -> str:
-        sorted_tiles = sorted(tiles)
-        if not sorted_tiles:
-            return "(empty)"
-        return " ".join(_TILE_SYMBOLS[t // 4] for t in sorted_tiles)
+    # ------------------------------------------------------------------
+    # Rendering helpers
+    # ------------------------------------------------------------------
+    def _load_tile_assets(self) -> None:
+        """Attempt to load SVG tile assets; fall back gracefully on failure."""
 
-    def _discards_to_text(self, tiles: Iterable[int]) -> str:
-        discards = [idx for idx, flagged in enumerate(tiles) if flagged]
-        if not discards:
-            return "(none)"
-        return " ".join(_TILE_SYMBOLS[t // 4] for t in discards)
+        self._raw_tile_assets.clear()
+        if not self._asset_root.exists():
+            return
 
-    def _draw_line(self, text: str, x: int, y: int, color: Tuple[int, int, int]) -> int:
-        if self._font is None or self._screen is None:
-            return y
-        surface = self._font.render(text, True, color)
-        self._screen.blit(surface, (x, y))
-        return y + self._line_height
+        for tile_index, symbol in enumerate(_TILE_SYMBOLS):
+            path = self._asset_root / f"{symbol}.svg"
+            if not path.exists():
+                continue
+            try:
+                surface = pygame.image.load(str(path))
+                surface = surface.convert_alpha()
+            except Exception:
+                continue
+            self._raw_tile_assets[tile_index] = surface
+
+    def _get_tile_color(self, tile_34: int) -> Tuple[int, int, int]:
+        symbol = _TILE_SYMBOLS[tile_34]
+        suit = symbol[-1] if symbol[-1] in {"m", "p", "s"} else "z"
+        palette = {
+            "m": (210, 90, 90),
+            "p": (90, 150, 225),
+            "s": (90, 190, 120),
+            "z": (220, 210, 150),
+        }
+        return palette.get(suit, (200, 200, 200))
+
+    def _create_tile_placeholder(self, tile_34: int, size: Tuple[int, int]) -> pygame.Surface:
+        key = (tile_34, size)
+        if key in self._placeholder_cache:
+            return self._placeholder_cache[key]
+
+        width = max(16, size[0])
+        height = max(24, size[1])
+        surface = pygame.Surface((width, height), pygame.SRCALPHA)
+        surface.fill(self._get_tile_color(tile_34))
+        pygame.draw.rect(surface, (245, 245, 245), surface.get_rect(), 2, border_radius=6)
+
+        label = _TILE_SYMBOLS[tile_34]
+        font_size = max(12, int(height * 0.45))
+        font = pygame.font.SysFont(self._font_name, font_size)
+        text = font.render(label, True, (20, 20, 20))
+        text_rect = text.get_rect(center=surface.get_rect().center)
+        surface.blit(text, text_rect)
+
+        self._placeholder_cache[key] = surface
+        return surface
+
+    def _get_tile_surface(
+        self,
+        tile_34: int,
+        size: Tuple[int, int],
+        face_up: bool = True,
+        orientation: int = 0,
+    ) -> pygame.Surface:
+        width = max(1, size[0])
+        height = max(1, size[1])
+        base_size = (width, height)
+
+        if not face_up:
+            return self._get_face_down_surface(base_size, orientation)
+
+        cache_key = (tile_34, base_size)
+        if cache_key not in self._tile_cache:
+            if tile_34 in self._raw_tile_assets:
+                try:
+                    surface = pygame.transform.smoothscale(
+                        self._raw_tile_assets[tile_34], base_size
+                    )
+                except pygame.error:
+                    surface = pygame.transform.scale(self._raw_tile_assets[tile_34], base_size)
+            else:
+                surface = self._create_tile_placeholder(tile_34, base_size)
+            self._tile_cache[cache_key] = surface
+
+        orientation = orientation % 360
+        if orientation == 0:
+            return self._tile_cache[cache_key]
+
+        orient_key = (tile_34, base_size, orientation)
+        if orient_key not in self._tile_orientation_cache:
+            self._tile_orientation_cache[orient_key] = pygame.transform.rotate(
+                self._tile_cache[cache_key], orientation
+            )
+        return self._tile_orientation_cache[orient_key]
+
+    def _get_face_down_surface(
+        self, size: Tuple[int, int], orientation: int = 0
+    ) -> pygame.Surface:
+        width = max(1, size[0])
+        height = max(1, size[1])
+        base_size = (width, height)
+        orientation = orientation % 360
+        cache_key = (base_size, orientation)
+        if cache_key not in self._face_down_cache:
+            surface = pygame.Surface(base_size, pygame.SRCALPHA)
+            surface.fill(self._face_down_color)
+            pygame.draw.rect(surface, self._face_down_border, surface.get_rect(), 2, border_radius=6)
+            if orientation:
+                surface = pygame.transform.rotate(surface, orientation)
+            self._face_down_cache[cache_key] = surface
+        return self._face_down_cache[cache_key]
+
+    def _get_discard_tiles(self, player_idx: int) -> list[int]:
+        if player_idx >= len(getattr(self, "discard_pile", [])):
+            return []
+        tiles = [idx for idx, flagged in enumerate(self.discard_pile[player_idx]) if flagged]
+        tiles.sort()
+        return [tile // 4 for tile in tiles]
+
+    def _compute_tile_metrics(self, play_rect: pygame.Rect) -> None:
+        width = max(1, play_rect.width)
+        height = max(1, play_rect.height)
+
+        south_tile_width = max(24, min(width // 20, 72))
+        south_tile_height = max(36, int(south_tile_width * 1.4))
+
+        north_tile_width = max(20, int(south_tile_width * 0.85))
+        north_tile_height = max(30, int(north_tile_width * 1.4))
+
+        side_tile_height = max(24, min(height // 16, int(south_tile_height * 0.85)))
+        side_tile_width = max(18, int(side_tile_height * 0.7))
+
+        discard_tile_width = max(18, int(south_tile_width * 0.85))
+        discard_tile_height = max(28, int(discard_tile_width * 1.3))
+
+        wall_tile_width = max(12, int(south_tile_width * 0.55))
+        wall_tile_height = max(18, int(wall_tile_width * 1.3))
+
+        meld_tile_width = max(20, int(discard_tile_width * 1.05))
+        meld_tile_height = max(28, int(meld_tile_width * 1.3))
+
+        self._tile_metrics = {
+            "south_hand": (south_tile_width, south_tile_height),
+            "north_hand": (north_tile_width, north_tile_height),
+            "side_hand": (side_tile_width, side_tile_height),
+            "discard": (discard_tile_width, discard_tile_height),
+            "wall": (wall_tile_width, wall_tile_height),
+            "meld": (meld_tile_width, meld_tile_height),
+        }
+
+    def _draw_center_panel(self, play_rect: pygame.Rect) -> pygame.Rect:
+        center_width = max(220, int(play_rect.width * 0.24))
+        center_height = max(150, int(play_rect.height * 0.24))
+        center_rect = pygame.Rect(0, 0, center_width, center_height)
+        center_rect.center = play_rect.center
+
+        pygame.draw.rect(self._screen, self._panel_color, center_rect, border_radius=12)
+        pygame.draw.rect(self._screen, self._panel_border, center_rect, 2, border_radius=12)
+
+        if self._header_font is None or self._small_font is None or self._font is None:
+            return center_rect
+
+        round_data = getattr(self, "round", [0, 0])
+        round_index = round_data[0] if isinstance(round_data[0], int) else 0
+        wind_names = ["East", "South", "West", "North"]
+        wind = wind_names[(round_index // 4) % 4]
+        hand_number = round_index % 4 + 1
+        round_text = f"{wind} {hand_number}"
+
+        title_surface = self._header_font.render(round_text, True, self._text_color)
+        title_rect = title_surface.get_rect()
+        title_rect.centerx = center_rect.centerx
+        title_rect.top = center_rect.top + 18
+        self._screen.blit(title_surface, title_rect)
+
+        honba = round_data[1] if len(round_data) > 1 and isinstance(round_data[1], int) else 0
+        riichi = getattr(self, "num_riichi", 0)
+        tiles_remaining = len(getattr(self, "deck", []))
+        counters = f"Honba {honba}  |  Riichi {riichi}  |  Tiles {tiles_remaining}"
+        counters_surface = self._small_font.render(counters, True, self._muted_text_color)
+        counters_rect = counters_surface.get_rect()
+        counters_rect.centerx = center_rect.centerx
+        counters_rect.top = title_rect.bottom + 12
+        self._screen.blit(counters_surface, counters_rect)
+
+        score_positions = {
+            0: (center_rect.centerx, center_rect.bottom + 28),
+            1: (center_rect.right + 36, center_rect.centery),
+            2: (center_rect.centerx, center_rect.top - 28),
+            3: (center_rect.left - 36, center_rect.centery),
+        }
+
+        scores = getattr(self, "scores", [])
+        current_player = getattr(self, "current_player", 0)
+        for idx, position in score_positions.items():
+            if idx >= len(scores):
+                continue
+            score_value = scores[idx] * 100
+            color = self._accent_color if idx == current_player else self._text_color
+            score_surface = self._font.render(f"{score_value:5d}", True, color)
+            score_rect = score_surface.get_rect(center=position)
+            self._screen.blit(score_surface, score_rect)
+
+        return center_rect
+
+    def _draw_tile_grid(
+        self,
+        tiles: list[int],
+        area: pygame.Rect,
+        tile_size: Tuple[int, int],
+        orientation: int,
+        columns: int,
+    ) -> None:
+        if not tiles:
+            return
+
+        columns = max(1, columns)
+        spacing = 4
+        for idx, tile in enumerate(tiles):
+            column = idx % columns
+            row = idx // columns
+            surface = self._get_tile_surface(tile, tile_size, True, orientation)
+            tile_width, tile_height = surface.get_size()
+            x = area.left + column * (tile_width + spacing)
+            y = area.top + row * (tile_height + spacing)
+            self._screen.blit(surface, (x, y))
+
+    def _draw_melds(
+        self,
+        player: int,
+        origin: Tuple[int, int],
+        direction: str,
+        tile_size: Tuple[int, int],
+        orientation: int,
+    ) -> None:
+        melds = getattr(self, "melds", [])
+        if player >= len(melds):
+            return
+
+        x, y = origin
+        spacing = 8
+        for meld in melds[player]:
+            tiles = [tile // 4 for tile in meld.get("m", [])]
+            opened = meld.get("opened", True)
+            cur_x, cur_y = x, y
+            for tile in tiles:
+                surface = (
+                    self._get_tile_surface(tile, tile_size, True, orientation)
+                    if opened
+                    else self._get_face_down_surface(tile_size, orientation)
+                )
+                self._screen.blit(surface, (cur_x, cur_y))
+                if direction == "horizontal":
+                    cur_x += surface.get_width() + 4
+                else:
+                    cur_y += surface.get_height() + 4
+            if direction == "horizontal":
+                x = cur_x + spacing
+            else:
+                y = cur_y + spacing
+
+    def _draw_south_area(self, play_rect: pygame.Rect) -> None:
+        if getattr(self, "num_players", 0) < 1:
+            return
+
+        hand_tiles = list(self.hands[0]) if self.hands else []
+        tile_size = self._tile_metrics.get("south_hand", (40, 56))
+        spacing = tile_size[0] + 6
+        draw_gap = spacing // 2
+        total_width = spacing * len(hand_tiles) + (draw_gap if len(hand_tiles) > 1 else 0)
+        start_x = play_rect.left + (play_rect.width - total_width) // 2
+        y = play_rect.bottom - tile_size[1] - 24
+        x = start_x
+        for idx, tile in enumerate(hand_tiles):
+            if len(hand_tiles) > 1 and idx == len(hand_tiles) - 1:
+                x += draw_gap
+            surface = self._get_tile_surface(tile // 4, tile_size, True, 0)
+            self._screen.blit(surface, (x, y))
+            x += spacing
+
+        hand_end_x = start_x + spacing * len(hand_tiles) + (draw_gap if len(hand_tiles) > 1 else 0)
+
+        discard_tiles = self._get_discard_tiles(0)
+        discard_tile = self._tile_metrics.get("discard", tile_size)
+        cols = 6
+        rows = max(1, (len(discard_tiles) + cols - 1) // cols)
+        grid_width = cols * (discard_tile[0] + 4)
+        grid_height = rows * (discard_tile[1] + 4)
+        discard_rect = pygame.Rect(0, 0, grid_width, grid_height)
+        discard_rect.centerx = play_rect.centerx
+        discard_rect.bottom = y - 12
+        self._draw_tile_grid(discard_tiles, discard_rect, discard_tile, 0, cols)
+
+        meld_tile = self._tile_metrics.get("meld", tile_size)
+        meld_origin_x = min(play_rect.right - meld_tile[0] * 4, hand_end_x + 16)
+        meld_origin_y = y
+        self._draw_melds(0, (meld_origin_x, meld_origin_y), "horizontal", meld_tile, 0)
+
+    def _draw_west_area(self, play_rect: pygame.Rect) -> None:
+        if getattr(self, "num_players", 0) < 2:
+            return
+
+        tile_size = self._tile_metrics.get("side_hand", (28, 40))
+        spacing = tile_size[1] + 4
+        hand_tiles = len(self.hands[1]) if len(self.hands) > 1 else 0
+        total_height = spacing * hand_tiles - (4 if hand_tiles else 0)
+        start_y = play_rect.top + (play_rect.height - total_height) // 2
+        start_y = max(play_rect.top + 20, start_y)
+        x = play_rect.right - tile_size[0] - 24
+        y = start_y
+        for _ in range(hand_tiles):
+            surface = self._get_face_down_surface(tile_size, 0)
+            self._screen.blit(surface, (x, y))
+            y += spacing
+
+        meld_tile = self._tile_metrics.get("meld", tile_size)
+        meld_origin_x = x - meld_tile[1] - 24
+        meld_origin_y = play_rect.centery - meld_tile[0]
+        self._draw_melds(1, (meld_origin_x, meld_origin_y), "horizontal", meld_tile, 270)
+
+        discard_tiles = self._get_discard_tiles(1)
+        discard_tile = self._tile_metrics.get("discard", tile_size)
+        rows = 3
+        cols = max(1, (len(discard_tiles) + rows - 1) // rows)
+        grid_width = cols * (discard_tile[0] + 4)
+        grid_height = rows * (discard_tile[1] + 4)
+        discard_rect = pygame.Rect(0, 0, grid_width, grid_height)
+        discard_rect.top = play_rect.centery - grid_height // 2
+        discard_rect.left = play_rect.centerx + 20
+        discard_rect.right = discard_rect.left + grid_width
+        if discard_rect.right > meld_origin_x - 12:
+            shift = discard_rect.right - (meld_origin_x - 12)
+            discard_rect.move_ip(-shift, 0)
+        self._draw_tile_grid(discard_tiles, discard_rect, discard_tile, 90, cols)
+
+    def _draw_north_area(self, play_rect: pygame.Rect) -> None:
+        if getattr(self, "num_players", 0) < 3:
+            return
+
+        tile_size = self._tile_metrics.get("north_hand", (32, 44))
+        spacing = tile_size[0] + 4
+        hand_tiles = len(self.hands[2]) if len(self.hands) > 2 else 0
+        total_width = spacing * hand_tiles - (4 if hand_tiles else 0)
+        start_x = play_rect.left + (play_rect.width - total_width) // 2
+        y = play_rect.top + 20
+        x = start_x
+        for _ in range(hand_tiles):
+            surface = self._get_face_down_surface(tile_size, 0)
+            self._screen.blit(surface, (x, y))
+            x += spacing
+
+        discard_tiles = self._get_discard_tiles(2)
+        discard_tile = self._tile_metrics.get("discard", tile_size)
+        cols = 6
+        rows = max(1, (len(discard_tiles) + cols - 1) // cols)
+        grid_width = cols * (discard_tile[0] + 4)
+        grid_height = rows * (discard_tile[1] + 4)
+        discard_rect = pygame.Rect(0, 0, grid_width, grid_height)
+        discard_rect.centerx = play_rect.centerx
+        discard_rect.top = y + tile_size[1] + 12
+        self._draw_tile_grid(discard_tiles, discard_rect, discard_tile, 180, cols)
+
+        meld_tile = self._tile_metrics.get("meld", tile_size)
+        meld_origin_x = play_rect.centerx - meld_tile[0] * 2
+        meld_origin_y = discard_rect.bottom + 12
+        self._draw_melds(2, (meld_origin_x, meld_origin_y), "horizontal", meld_tile, 180)
+
+    def _draw_east_area(self, play_rect: pygame.Rect) -> None:
+        if getattr(self, "num_players", 0) < 4:
+            return
+
+        tile_size = self._tile_metrics.get("side_hand", (28, 40))
+        spacing = tile_size[1] + 4
+        hand_tiles = len(self.hands[3]) if len(self.hands) > 3 else 0
+        total_height = spacing * hand_tiles - (4 if hand_tiles else 0)
+        start_y = play_rect.top + (play_rect.height - total_height) // 2
+        start_y = max(play_rect.top + 20, start_y)
+        x = play_rect.left + 24
+        y = start_y
+        for _ in range(hand_tiles):
+            surface = self._get_face_down_surface(tile_size, 0)
+            self._screen.blit(surface, (x, y))
+            y += spacing
+
+        meld_tile = self._tile_metrics.get("meld", tile_size)
+        meld_origin_x = x + tile_size[0] + 24
+        meld_origin_y = play_rect.centery - meld_tile[0]
+        self._draw_melds(3, (meld_origin_x, meld_origin_y), "horizontal", meld_tile, 90)
+
+        discard_tiles = self._get_discard_tiles(3)
+        discard_tile = self._tile_metrics.get("discard", tile_size)
+        rows = 3
+        cols = max(1, (len(discard_tiles) + rows - 1) // rows)
+        grid_width = cols * (discard_tile[0] + 4)
+        grid_height = rows * (discard_tile[1] + 4)
+        discard_rect = pygame.Rect(0, 0, grid_width, grid_height)
+        discard_rect.top = play_rect.centery - grid_height // 2
+        discard_rect.right = play_rect.centerx - 20
+        discard_rect.left = discard_rect.right - grid_width
+        if discard_rect.left < meld_origin_x + meld_tile[0] + 12:
+            shift = (meld_origin_x + meld_tile[0] + 12) - discard_rect.left
+            discard_rect.move_ip(shift, 0)
+        self._draw_tile_grid(discard_tiles, discard_rect, discard_tile, 270, cols)
+
+    def _draw_walls(self, play_rect: pygame.Rect) -> None:
+        wall_tile = self._tile_metrics.get("wall", (20, 26))
+        tiles_per_side = 17
+        spacing = 4
+
+        # Top and bottom walls
+        top_y = play_rect.top - wall_tile[1] - 12
+        bottom_y = play_rect.bottom + 12
+        available_width = play_rect.width - 40
+        horizontal_spacing = max(
+            wall_tile[0] + spacing,
+            (available_width - wall_tile[0]) / max(1, tiles_per_side - 1),
+        )
+        for i in range(tiles_per_side):
+            x = int(play_rect.left + 20 + i * horizontal_spacing)
+            surface = self._get_face_down_surface(wall_tile, 0)
+            self._screen.blit(surface, (x, top_y))
+            self._screen.blit(surface, (x, bottom_y))
+
+        # Left and right walls
+        left_x = play_rect.left - wall_tile[0] - 12
+        right_x = play_rect.right + 12
+        available_height = play_rect.height - 40
+        vertical_spacing = max(
+            wall_tile[1] + spacing,
+            (available_height - wall_tile[1]) / max(1, tiles_per_side - 1),
+        )
+        for i in range(tiles_per_side):
+            y = int(play_rect.top + 20 + i * vertical_spacing)
+            surface = self._get_face_down_surface(wall_tile, 0)
+            self._screen.blit(surface, (left_x, y))
+            self._screen.blit(surface, (right_x, y))
+
+        self._draw_dead_wall(play_rect, wall_tile)
+
+    def _draw_dead_wall(self, play_rect: pygame.Rect, wall_tile: Tuple[int, int]) -> None:
+        dead_wall_tiles = getattr(self, "dead_wall", [])
+        stack_size = max(1, len(dead_wall_tiles) // 2) if dead_wall_tiles else 7
+        gap = 6
+        total_height = stack_size * (wall_tile[1] + gap) - gap
+        x = play_rect.right + wall_tile[0] * 2 + 24
+        start_y = play_rect.centery - total_height // 2
+
+        for i in range(stack_size):
+            y = start_y + i * (wall_tile[1] + gap)
+            surface = self._get_face_down_surface(wall_tile, 0)
+            self._screen.blit(surface, (x, y))
+
+        if getattr(self, "dora_indicator", []):
+            tile = self.dora_indicator[-1] // 4
+            indicator_size = (int(wall_tile[0] * 1.1), int(wall_tile[1] * 1.1))
+            surface = self._get_tile_surface(tile, indicator_size, True, 270)
+            rect = surface.get_rect()
+            rect.midleft = (
+                x + wall_tile[0] + 14,
+                start_y + (stack_size - 1) * (wall_tile[1] + gap) + wall_tile[1] // 2,
+            )
+            self._screen.blit(surface, rect)
+
+    def _draw_seat_labels(self, play_rect: pygame.Rect) -> None:
+        if self._small_font is None:
+            return
+
+        num_players = getattr(self, "num_players", 0)
+        seat_names = list(getattr(self, "seat_names", []))
+        if len(seat_names) < num_players:
+            seat_names.extend(["NoName"] * (num_players - len(seat_names)))
+
+        label_positions = {
+            0: (play_rect.centerx, play_rect.bottom + 32),
+            1: (play_rect.right + 40, play_rect.centery),
+            2: (play_rect.centerx, play_rect.top - 32),
+            3: (play_rect.left - 40, play_rect.centery),
+        }
+
+        for idx in range(min(4, num_players)):
+            name = seat_names[idx] if idx < len(seat_names) else "NoName"
+            surface = self._small_font.render(name, True, self._muted_text_color)
+            rect = surface.get_rect(center=label_positions[idx])
+            self._screen.blit(surface, rect)
+
+        dealer = getattr(self, "oya", 0)
+        if dealer >= min(4, num_players):
+            return
+
+        offsets = {
+            0: (0, -22),
+            1: (-22, 0),
+            2: (0, 22),
+            3: (22, 0),
+        }
+        marker_center = (
+            label_positions[dealer][0] + offsets[dealer][0],
+            label_positions[dealer][1] + offsets[dealer][1],
+        )
+        pygame.draw.circle(self._screen, self._accent_color, marker_center, 10, width=2)
+        marker_surface = self._small_font.render("E", True, self._accent_color)
+        marker_rect = marker_surface.get_rect(center=marker_center)
+        self._screen.blit(marker_surface, marker_rect)
+
+    def _draw_status_text(self, surface_width: int) -> None:
+        if self._small_font is None:
+            return
+
+        margin = 16
+        phase_text = f"Phase: {self.phase}  |  Current Player: P{self.current_player}"
+        phase_surface = self._small_font.render(phase_text, True, self._accent_color)
+        self._screen.blit(phase_surface, (margin, margin))
+
+        info_text = self._last_payload.info.get("msg") or getattr(self, "msg", "")
+        if info_text:
+            info_surface = self._small_font.render(str(info_text), True, self._text_color)
+            self._screen.blit(info_surface, (margin, margin + phase_surface.get_height() + 6))
+
+        reward_color = self._danger_color if self._last_payload.reward < 0 else self._text_color
+        reward_text = f"Action: {self._last_payload.action}  Reward: {self._last_payload.reward:.2f}"
+        reward_surface = self._small_font.render(reward_text, True, reward_color)
+        reward_rect = reward_surface.get_rect()
+        reward_rect.topright = (surface_width - margin, margin)
+        self._screen.blit(reward_surface, reward_rect)
+
+        if self._last_payload.done:
+            done_surface = self._small_font.render("Episode finished", True, self._danger_color)
+            done_rect = done_surface.get_rect()
+            done_rect.topright = (surface_width - margin, reward_rect.bottom + 4)
+            self._screen.blit(done_surface, done_rect)
 
     def _render(self) -> None:
         if self._screen is None or self._font is None or self._clock is None:
             return
 
         self._screen.fill(self._background_color)
-        x_margin, y = 16, 16
-        title = f"MahjongEnv — Phase: {self.phase} — Current Player: P{self.current_player}"
-        y = self._draw_line(title, x_margin, y, self._accent_color)
+        width, height = self._screen.get_size()
+        min_dim = min(width, height)
+        play_size = min(max(260, int(min_dim * 0.72)), max(200, min_dim - 60))
+        play_rect = pygame.Rect(0, 0, play_size, play_size)
+        play_rect.center = (width // 2, height // 2)
 
-        for idx, hand in enumerate(self.hands):
-            prefix = "➤" if idx == self.current_player and not self.done else " "
-            text = f"{prefix} P{idx} Hand: {self._hand_to_text(hand)}"
-            y = self._draw_line(text, x_margin, y, self._text_color)
-            if idx < len(self.discard_pile):
-                discards = self._discards_to_text(self.discard_pile[idx])
-                y = self._draw_line(f"   Discards: {discards}", x_margin + 12, y, self._text_color)
+        pygame.draw.rect(self._screen, self._play_area_color, play_rect, border_radius=16)
+        pygame.draw.rect(self._screen, self._play_area_border, play_rect, 3, border_radius=16)
 
-        if self.melds:
-            y += 6
-            for idx, melds in enumerate(self.melds):
-                if not melds:
-                    continue
-                meld_text = ", ".join(meld["type"] for meld in melds)
-                y = self._draw_line(f"P{idx} Melds: {meld_text}", x_margin, y, self._text_color)
-
-        y += 8
-        reward_color = self._danger_color if self._last_payload.reward < 0 else self._text_color
-        y = self._draw_line(
-            f"Last Action: {self._last_payload.action} — Reward: {self._last_payload.reward:.2f}",
-            x_margin,
-            y,
-            reward_color,
-        )
-        msg = self._last_payload.info.get("msg") or getattr(self, "msg", "")
-        if msg:
-            y = self._draw_line(f"Message: {msg}", x_margin, y, self._text_color)
-
-        if self._last_payload.done:
-            y = self._draw_line("Episode finished", x_margin, y + 4, self._danger_color)
+        self._compute_tile_metrics(play_rect)
+        self._draw_walls(play_rect)
+        self._draw_center_panel(play_rect)
+        self._draw_south_area(play_rect)
+        self._draw_west_area(play_rect)
+        self._draw_north_area(play_rect)
+        self._draw_east_area(play_rect)
+        self._draw_seat_labels(play_rect)
+        self._draw_status_text(width)
 
         pygame.display.flip()
         self._clock.tick(self._fps)


### PR DESCRIPTION
## Summary
- load Mahjong tile SVGs when available and provide placeholder rendering fallbacks
- rebuild the pygame GUI with a table-centric layout including walls, center panel, player areas, and seat markers
- add helper rendering routines for discards, melds, and status overlays to match the requested presentation

## Testing
- python -m compileall src/mahjong_wrapper.py

------
https://chatgpt.com/codex/tasks/task_e_68da185914a0832aa35bf91e4dcdce30