### PR TITLE
Adjust play area layout and wall placement in GUI

### DIFF
--- a/src/mahjong_wrapper.py
+++ b/src/mahjong_wrapper.py
@@ -287,31 +287,18 @@ class MahjongEnv(_BaseMahjongEnv):
         width = max(1, play_rect.width)
         height = max(1, play_rect.height)
 
-        south_tile_width = max(24, min(width // 20, 72))
-        south_tile_height = max(36, int(south_tile_width * 1.4))
-
-        north_tile_width = max(20, int(south_tile_width * 0.85))
-        north_tile_height = max(30, int(north_tile_width * 1.4))
-
-        side_tile_height = max(24, min(height // 16, int(south_tile_height * 0.85)))
-        side_tile_width = max(18, int(side_tile_height * 0.7))
-
-        discard_tile_width = max(18, int(south_tile_width * 0.85))
-        discard_tile_height = max(28, int(discard_tile_width * 1.3))
-
-        wall_tile_width = max(12, int(south_tile_width * 0.55))
-        wall_tile_height = max(18, int(wall_tile_width * 1.3))
-
-        meld_tile_width = max(20, int(discard_tile_width * 1.05))
-        meld_tile_height = max(28, int(meld_tile_width * 1.3))
+        base_width = max(24, min(width // 18, height // 18, 72))
+        base_height = max(36, int(base_width * 1.4))
+        tile_size = (base_width, base_height)
 
         self._tile_metrics = {
-            "south_hand": (south_tile_width, south_tile_height),
-            "north_hand": (north_tile_width, north_tile_height),
-            "side_hand": (side_tile_width, side_tile_height),
-            "discard": (discard_tile_width, discard_tile_height),
-            "wall": (wall_tile_width, wall_tile_height),
-            "meld": (meld_tile_width, meld_tile_height),
+            "base": tile_size,
+            "south_hand": tile_size,
+            "north_hand": tile_size,
+            "side_hand": tile_size,
+            "discard": tile_size,
+            "wall": tile_size,
+            "meld": tile_size,
         }
 
     def _draw_center_panel(self, play_rect: pygame.Rect) -> pygame.Rect:
@@ -439,6 +426,24 @@ class MahjongEnv(_BaseMahjongEnv):
             else:
                 y = cur_y + spacing
 
+    def _draw_wall_segment(
+        self,
+        surface: pygame.Surface,
+        start: Tuple[int, int],
+        tile_size: Tuple[int, int],
+        count: int,
+        spacing: int = 4,
+    ) -> None:
+        if count <= 0:
+            return
+
+        tile_surface = self._get_face_down_surface(tile_size, 0)
+        tile_width, _ = tile_surface.get_size()
+        x, y = start
+        for _ in range(count):
+            surface.blit(tile_surface, (x, y))
+            x += tile_width + spacing
+
     def _draw_player_layout(
         self,
         target_surface: pygame.Surface,
@@ -448,16 +453,78 @@ class MahjongEnv(_BaseMahjongEnv):
         area = target_surface.get_rect()
         margin_side = 28
         margin_bottom = 28
+        margin_top = 24
 
         tile_size = self._tile_metrics.get("south_hand", (40, 56))
-        spacing = tile_size[0] + 6
+        tile_width, tile_height = tile_size
+        spacing = tile_width + 6
         draw_gap = spacing // 2
+
+        wall_gap = 12
+        discard_gap = 16
 
         hands = getattr(self, "hands", [])
         hand_tiles = list(hands[player_idx]) if player_idx < len(hands) else []
 
+        hand_y = area.bottom - margin_bottom - tile_height
+        wall_y = hand_y - wall_gap - tile_height
+        if wall_y < margin_top + tile_height:
+            wall_y = margin_top + tile_height
+            hand_y = wall_y + wall_gap + tile_height
+
+        discard_tiles = self._get_discard_tiles(player_idx)
+        discard_tile = self._tile_metrics.get("discard", tile_size)
+        if discard_tiles:
+            cols = 6
+            grid_spacing = 4
+            rows = max(1, (len(discard_tiles) + cols - 1) // cols)
+            grid_width = cols * discard_tile[0] + (cols - 1) * grid_spacing
+            grid_height = rows * discard_tile[1] + (rows - 1) * grid_spacing
+            discard_bottom = wall_y - discard_gap
+            discard_top = max(margin_top, discard_bottom - grid_height)
+            discard_rect = pygame.Rect(
+                int(area.centerx - grid_width / 2),
+                int(discard_top),
+                int(grid_width),
+                int(grid_height),
+            )
+            self._draw_tile_grid(
+                discard_tiles,
+                discard_rect,
+                discard_tile,
+                0,
+                cols,
+                target_surface,
+            )
+
+        wall_tile = self._tile_metrics.get("wall", tile_size)
+        wall_spacing = 4
+        wall_count = 17
+        max_wall_width = area.width - 2 * margin_side
+        tile_surface = self._get_face_down_surface(wall_tile, 0)
+        tile_surface_width, tile_surface_height = tile_surface.get_size()
+        wall_width = wall_count * tile_surface_width + (wall_count - 1) * wall_spacing
+        if wall_width > max_wall_width and wall_count > 1:
+            wall_spacing = max(
+                1,
+                (max_wall_width - wall_count * tile_surface_width) // (wall_count - 1),
+            )
+            wall_width = wall_count * tile_surface_width + (wall_count - 1) * wall_spacing
+        wall_x = max(
+            margin_side,
+            min(area.centerx - wall_width // 2, area.width - margin_side - wall_width),
+        )
+        wall_y_pos = wall_y - (tile_surface_height - tile_height) // 2
+        self._draw_wall_segment(
+            target_surface,
+            (int(wall_x), int(wall_y_pos)),
+            wall_tile,
+            wall_count,
+            spacing=wall_spacing,
+        )
+
         x = margin_side
-        y = area.bottom - tile_size[1] - margin_bottom
+        y = int(hand_y)
         for idx, tile in enumerate(hand_tiles):
             if len(hand_tiles) > 1 and idx == len(hand_tiles) - 1:
                 x += draw_gap
@@ -465,20 +532,10 @@ class MahjongEnv(_BaseMahjongEnv):
                 tile_surface = self._get_tile_surface(tile // 4, tile_size, True, 0)
             else:
                 tile_surface = self._get_face_down_surface(tile_size, 0)
-            target_surface.blit(tile_surface, (x, y))
+            target_surface.blit(tile_surface, (int(x), y))
             x += spacing
 
         hand_end_x = x if hand_tiles else margin_side
-
-        discard_tiles = self._get_discard_tiles(player_idx)
-        discard_tile = self._tile_metrics.get("discard", tile_size)
-        cols = 6
-        rows = max(1, (len(discard_tiles) + cols - 1) // cols)
-        grid_width = cols * (discard_tile[0] + 4)
-        grid_height = rows * (discard_tile[1] + 4)
-        discard_rect = pygame.Rect(area.centerx-grid_width/2, 0, grid_width, grid_height)
-        discard_rect.top = y - 3 * (discard_tile[1] + 4) # maximum 3 rows
-        self._draw_tile_grid(discard_tiles, discard_rect, discard_tile, 0, cols, target_surface)
 
         meld_tile = self._tile_metrics.get("meld", tile_size)
         max_meld_width = meld_tile[0] * 4 + 12
@@ -490,7 +547,7 @@ class MahjongEnv(_BaseMahjongEnv):
         meld_origin_y = y
         self._draw_melds(
             player_idx,
-            (meld_origin_x, meld_origin_y),
+            (int(meld_origin_x), meld_origin_y),
             "horizontal",
             meld_tile,
             0,
@@ -519,41 +576,6 @@ class MahjongEnv(_BaseMahjongEnv):
                 rendered = layout_surface
             rect = rendered.get_rect(center=play_rect.center)
             self._screen.blit(rendered, rect)
-
-    def _draw_walls(self, play_rect: pygame.Rect) -> None:
-        wall_tile = self._tile_metrics.get("wall", (20, 26))
-        tiles_per_side = 17
-        spacing = 4
-
-        # Top and bottom walls
-        top_y = play_rect.top - wall_tile[1] - 12
-        bottom_y = play_rect.bottom + 12
-        available_width = play_rect.width - 40
-        horizontal_spacing = max(
-            wall_tile[0] + spacing,
-            (available_width - wall_tile[0]) / max(1, tiles_per_side - 1),
-        )
-        for i in range(tiles_per_side):
-            x = int(play_rect.left + 20 + i * horizontal_spacing)
-            surface = self._get_face_down_surface(wall_tile, 0)
-            self._screen.blit(surface, (x, top_y))
-            self._screen.blit(surface, (x, bottom_y))
-
-        # Left and right walls
-        left_x = play_rect.left - wall_tile[0] - 12
-        right_x = play_rect.right + 12
-        available_height = play_rect.height - 40
-        vertical_spacing = max(
-            wall_tile[1] + spacing,
-            (available_height - wall_tile[1]) / max(1, tiles_per_side - 1),
-        )
-        for i in range(tiles_per_side):
-            y = int(play_rect.top + 20 + i * vertical_spacing)
-            surface = self._get_face_down_surface(wall_tile, 0)
-            self._screen.blit(surface, (left_x, y))
-            self._screen.blit(surface, (right_x, y))
-
-        self._draw_dead_wall(play_rect, wall_tile)
 
     def _draw_dead_wall(self, play_rect: pygame.Rect, wall_tile: Tuple[int, int]) -> None:
         dead_wall_tiles = getattr(self, "dead_wall", [])
@@ -653,18 +675,25 @@ class MahjongEnv(_BaseMahjongEnv):
 
         self._screen.fill(self._background_color)
         width, height = self._screen.get_size()
-        min_dim = min(width, height)
-        play_size = min(max(260, int(min_dim * 0.72)), max(200, min_dim - 60))
-        play_rect = pygame.Rect(0, 0, play_size, play_size)
-        play_rect.center = (width // 2, height // 2)
+
+        if height <= width:
+            play_size = height
+            play_rect = pygame.Rect(0, 0, play_size, play_size)
+            play_rect.centerx = width // 2
+            play_rect.top = 0
+        else:
+            play_size = width
+            play_rect = pygame.Rect(0, 0, play_size, play_size)
+            play_rect.center = (width // 2, height // 2)
 
         pygame.draw.rect(self._screen, self._play_area_color, play_rect, border_radius=16)
         pygame.draw.rect(self._screen, self._play_area_border, play_rect, 3, border_radius=16)
 
         self._compute_tile_metrics(play_rect)
-        self._draw_walls(play_rect)
         self._draw_center_panel(play_rect)
         self._draw_player_areas(play_rect)
+        wall_tile = self._tile_metrics.get("wall", (20, 26))
+        self._draw_dead_wall(play_rect, wall_tile)
         self._draw_seat_labels(play_rect)
         self._draw_status_text(width)
 


### PR DESCRIPTION
## Summary
- align the play area square to the window height when possible and keep tile sizing consistent
- reposition per-player wall tiles between each hand and discard region to avoid overlaps
- retain dead wall rendering using the new tile sizing scheme

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68da857c5ce0832aa4e33f73cfbeac31